### PR TITLE
Make bot commands case-insensitive and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Guide for sp0rkle
+
+This guide provides information for AI agents working on the sp0rkle codebase.
+
+## Coding Style
+
+- **Language**: Go.
+- **Formatting**: Follow standard Go formatting (`gofmt`). Use tabs for indentation.
+- **Logging**: Use the `github.com/fluffle/golog/logging` package for all logging.
+- **Error Handling**: Follow standard Go error handling patterns.
+- **Conventions**:
+    - Multi-word commands should be supported case-insensitively.
+    - All command registrations should be done using `bot.Command`.
+    - Use `bot.Context` for interacting with IRC, but be aware of the planned migration to standard `context.Context`.
+
+## Testing Strategy
+
+- **Test Files**: Always include `_test.go` files for new functionality.
+- **Patterns**: Prefer table-driven tests.
+- **Running Tests**: Use `go test ./...` from the root directory to run all tests.
+- **Mocks**: Some packages use `github.com/golang/mock` for mocking IRC connections and other interfaces.
+
+## Persistence
+
+- The project uses a mix of MongoDB (via `gopkg.in/mgo.v2`) and BoltDB (via `go.etcd.io/bbolt`).
+- There is an ongoing effort to migrate from MongoDB to BoltDB.
+- Check `bot/bot.go` for migration logic.
+
+## Command Set
+
+- Command matching is case-insensitive.
+- Command prefixes are stored in lowercase in the `CommandSet`.
+- Matching uses the longest prefix that matches the input case-insensitively.
+- Arguments passed to command handlers preserve their original case.

--- a/bot/commandset.go
+++ b/bot/commandset.go
@@ -57,6 +57,7 @@ func (cs *commandSet) Add(r Runner, prefix string) {
 		logging.Error("Prefix or runner empty when adding command.", prefix)
 		return
 	}
+	prefix = strings.ToLower(prefix)
 	cs.Lock()
 	defer cs.Unlock()
 	if _, ok := cs.set[prefix]; ok {
@@ -71,8 +72,9 @@ func (cs *commandSet) match(txt string) (final Runner, prefixlen int) {
 	cs.RLock()
 	defer cs.RUnlock()
 
+	lowerTxt := strings.ToLower(txt)
 	for prefix, r := range cs.set {
-		if !strings.HasPrefix(txt, prefix) {
+		if !strings.HasPrefix(lowerTxt, prefix) {
 			continue
 		}
 		if final == nil || len(prefix) > prefixlen {
@@ -88,7 +90,8 @@ func (cs *commandSet) possible(txt string) []string {
 	defer cs.RUnlock()
 
 	poss := []string{}
-	words := strings.Fields(txt)
+	lowerTxt := strings.ToLower(txt)
+	words := strings.Fields(lowerTxt)
 	for prefix := range cs.set {
 		for _, w := range words {
 			if strings.Contains(prefix, w) {

--- a/bot/commandset_test.go
+++ b/bot/commandset_test.go
@@ -1,0 +1,125 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+)
+
+type dummyRunner struct {
+	help string
+	args string
+}
+
+func (r *dummyRunner) Run(ctx *Context) {
+	r.args = ctx.Args[1]
+}
+func (r *dummyRunner) Help() string { return r.help }
+
+func TestCommandSetMatch(t *testing.T) {
+	cs := newCommandSet()
+	cs.Add(&dummyRunner{help: "remind help"}, "remind")
+	cs.Add(&dummyRunner{help: "remind list help"}, "remind list")
+
+	tests := []struct {
+		input  string
+		prefix string
+		found  bool
+	}{
+		{"remind", "remind", true},
+		{"Remind", "remind", true},
+		{"remind list", "remind list", true},
+		{"REMIND LIST", "remind list", true},
+		{"remind me", "remind", true},
+		{"Remind me", "remind", true},
+		{"not a command", "", false},
+	}
+
+	for _, tc := range tests {
+		r, ln := cs.match(tc.input)
+		if !tc.found {
+			if r != nil {
+				t.Errorf("match(%q) = %v, want nil", tc.input, r)
+			}
+			continue
+		}
+		if r == nil {
+			t.Errorf("match(%q) = nil, want %q", tc.input, tc.prefix)
+			continue
+		}
+		if r.Help() != tc.prefix+" help" {
+			t.Errorf("match(%q) returned wrong runner: got %q, want %q", tc.input, r.Help(), tc.prefix+" help")
+		}
+
+		// Verify ln
+		if ln != len(tc.prefix) {
+			t.Errorf("match(%q) returned wrong ln: got %d, want %d", tc.input, ln, len(tc.prefix))
+		}
+	}
+}
+
+func TestCommandSetHandle(t *testing.T) {
+	cs := newCommandSet()
+	runner := &dummyRunner{help: "remind help"}
+	cs.Add(runner, "remind")
+
+	// We need a Context to call Handle, but Handle creates its own context from Line.
+	// Actually Handle calls reqContext(conn, line).
+	// reqContext uses bot.rewriters, which might be nil if not initialized.
+
+	// Let's just test the logic that Handle uses.
+	tests := []struct {
+		input    string
+		wantArgs string
+	}{
+		{"remind Me to do something", "Me to do something"},
+		{"REMIND me To Do Something", "me To Do Something"},
+	}
+
+	for _, tc := range tests {
+		r, ln := cs.match(tc.input)
+		if r == nil {
+			t.Fatalf("match(%q) returned nil", tc.input)
+		}
+		// This is the logic from Handle:
+		args := strings.Join(strings.Fields(tc.input[ln:]), " ")
+		if args != tc.wantArgs {
+			t.Errorf("Handle logic for %q: got args %q, want %q", tc.input, args, tc.wantArgs)
+		}
+	}
+}
+
+func TestCommandSetPossible(t *testing.T) {
+	cs := newCommandSet()
+	cs.Add(&dummyRunner{help: ""}, "remind")
+	cs.Add(&dummyRunner{help: ""}, "remind list")
+
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"remind", []string{"remind", "remind list"}},
+		{"REMIND", []string{"remind", "remind list"}},
+		{"list", []string{"remind list"}},
+		{"LIST", []string{"remind list"}},
+	}
+
+	for _, tc := range tests {
+		got := cs.possible(tc.input)
+		if len(got) != len(tc.want) {
+			t.Errorf("possible(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+		// Check if all wanted are in got
+		for _, w := range tc.want {
+			found := false
+			for _, g := range got {
+				if g == w {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("possible(%q) missing %q", tc.input, w)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This change makes all bot commands case-insensitive, addressing the issue where "Remind Me" wouldn't match "remind me". It includes a new test file `bot/commandset_test.go` to verify the behavior and an `AGENTS.md` file documenting the codebase for future agents.

---
*PR created automatically by Jules for task [2049869490340424727](https://jules.google.com/task/2049869490340424727) started by @gundalow*