### PR TITLE
Fix date parsing and reminder logic bugs

### DIFF
--- a/collections/reminders/reminders.go
+++ b/collections/reminders/reminders.go
@@ -115,7 +115,7 @@ func (r *Reminder) Reply() (s string) {
 func (r *Reminder) Acknowledge() (s string) {
 	switch {
 	case r.Tell:
-		s = fmt.Sprintf("okay, i'll tell %s %s when I see them",
+		return fmt.Sprintf("okay, i'll tell %s %s when I see them",
 			r.Target, r.Reminder)
 	case r.From == r.To:
 		s = fmt.Sprintf("okay, i'll remind you %s at %s",
@@ -124,6 +124,9 @@ func (r *Reminder) Acknowledge() (s string) {
 		s = fmt.Sprintf("okay, i'll remind %s %s at %s",
 			r.Target, r.Reminder, r.At())
 	}
+	if r.RemindAt.Year() > time.Now().Year() {
+		s += " (NEXT YEAR)"
+	}
 	return
 }
 
@@ -131,11 +134,11 @@ func (r *Reminder) List(nick string) (s string) {
 	nick = strings.ToLower(nick)
 	switch {
 	case r.Tell && nick == r.From:
-		s = fmt.Sprintf("you asked me to tell %s %s",
+		return fmt.Sprintf("you asked me to tell %s %s",
 			r.Target, r.Reminder)
 	case r.Tell && nick == r.To:
 		// this is somewhat unlikely, as it should have triggered already
-		s = fmt.Sprintf("%s asked me to tell you %s -- and now I have!",
+		return fmt.Sprintf("%s asked me to tell you %s -- and now I have!",
 			r.Source, r.Reminder)
 	case nick == r.From && nick == r.To:
 		s = fmt.Sprintf("you asked me to remind you %s, at %s",
@@ -149,6 +152,9 @@ func (r *Reminder) List(nick string) (s string) {
 	default:
 		s = fmt.Sprintf("%s asked me to remind %s %s, at %s",
 			r.Source, r.Target, r.Reminder, r.At())
+	}
+	if !r.Tell && r.RemindAt.Year() > time.Now().Year() {
+		s += " (NEXT YEAR)"
 	}
 	return
 }

--- a/drivers/reminddriver/commands.go
+++ b/drivers/reminddriver/commands.go
@@ -67,6 +67,7 @@ func set(ctx *bot.Context) {
 	z := datetime.ZoneOrLocal(conf.Zone(ctx.Nick))
 	// Parse the reminder time from the input.
 	at, err, reminder, timestr := time.Now(), error(nil), "", ""
+	nextUsed := false
 	for i := 1; i+1 < len(s); i++ {
 		lc := strings.ToLower(s[i])
 		if lc == "in" || lc == "at" || lc == "on" {
@@ -78,8 +79,10 @@ func set(ctx *bot.Context) {
 		} else {
 			continue
 		}
-		at, err = datetime.ParseZ(timestr, z)
+		res, err := datetime.ParseXZ(timestr, z)
 		if err == nil {
+			at = res.Time
+			nextUsed = res.NextUsed
 			reminder = strings.Join(s[1:i], " ")
 			break
 		}
@@ -93,10 +96,6 @@ func set(ctx *bot.Context) {
 		return
 	}
 	now := time.Now()
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, datetime.TZ())
-	if at.Before(now) && at.After(start) {
-		at = at.Add(24 * time.Hour)
-	}
 	if at.Before(now) {
 		ctx.ReplyN("Time %q is in the past.", timestr)
 		return
@@ -115,7 +114,11 @@ func set(ctx *bot.Context) {
 	}
 	// Any previously-generated list of reminders is now obsolete.
 	delete(listed, ctx.Nick)
-	ctx.ReplyN("%s", r.Acknowledge())
+	ack := r.Acknowledge()
+	if nextUsed {
+		ack += " (Note: 'next' is ambiguous, I've interpreted it as the coming occurrence)"
+	}
+	ctx.ReplyN("%s", ack)
 	Remind(r, ctx)
 }
 
@@ -130,13 +133,15 @@ func snooze(ctx *bot.Context) {
 	z := datetime.ZoneOrLocal(conf.Zone(ctx.Nick))
 	now := time.Now().In(z)
 	at := now.Add(30 * time.Minute)
+	nextUsed := false
 	if ctx.Text() != "" {
-		var err error
-		at, err = datetime.ParseZ(ctx.Text(), z)
+		res, err := datetime.ParseXZ(ctx.Text(), z)
 		if err != nil {
 			ctx.ReplyN("Couldn't parse time string %q: %v.", ctx.Text(), err)
 			return
 		}
+		at = res.Time
+		nextUsed = res.NextUsed
 		if at.Before(now) {
 			ctx.ReplyN("You can't snooze reminder into the past, fool.")
 			return
@@ -149,7 +154,11 @@ func snooze(ctx *bot.Context) {
 		return
 	}
 	delete(listed, ctx.Nick)
-	ctx.ReplyN("%s", r.Acknowledge())
+	ack := r.Acknowledge()
+	if nextUsed {
+		ack += " (Note: 'next' is ambiguous, I've interpreted it as the coming occurrence)"
+	}
+	ctx.ReplyN("%s", ack)
 	Remind(r, ctx)
 }
 

--- a/util/datetime/datetime_test.go
+++ b/util/datetime/datetime_test.go
@@ -18,7 +18,8 @@ type timeTests []timeTest
 func (tt timeTests) run(t *testing.T, start time.Time) {
 	for i, test := range tt {
 		DPrintf("\nStarting parse of %q\n\n", test.in)
-		ret, err := parse(test.in, start)
+		res, err := parseX(test.in, start)
+		ret := res.Time
 		DPrintf("\nEnding parse of %q\n", test.in)
 		if err != nil || !ret.Equal(test.t) {
 			t.Errorf("Unable to parse test %d\nin: %s\nexp: %s\ngot: %s (err=%v)",
@@ -229,13 +230,13 @@ func TestParseDate(t *testing.T) {
 		{"2/3/68", mkt(2068, 3, 2)},
 		{"2/3/69", mkt(1969, 3, 2)},
 		// T_THE T_INTEGER T_DAYQUAL
-		{"the 1st", mkt(1, 2, 1)},
-		{"the 2nd", mkt(1, 2, 2)},
+		{"the 1st", mkt(2, 2, 1)},
+		{"the 2nd", mkt(2, 2, 2)},
 		{"the 10th", mkt(1, 2, 10)},
 		{"the 29th", mkt(1, 3, 1)},
 		// T_THE T_INTEGER T_DAYQUAL T_OF T_MONTHNAME
-		{"the 1st of January", mkt(1, 1, 1)},
-		{"the 2nd of February", mkt(1, 2, 2)},
+		{"the 1st of January", mkt(2, 1, 1)},
+		{"the 2nd of February", mkt(2, 2, 2)},
 		{"the 10th of March", mkt(1, 3, 10)},
 		{"the 31st of December", mkt(1, 12, 31)},
 		// T_THE T_INTEGER T_DAYQUAL T_OF T_MONTHNAME o_comma T_INTEGER
@@ -434,24 +435,24 @@ func TestParseRelativeMonths(t *testing.T) {
 		{"this december", mkt(6)},
 		{"next december", mkt(6)},
 		{"last december", mkt(-6)},
-		{"january", mkt(-5)},
-		{"this january", mkt(-5)},
+		{"january", mkt(7)},
+		{"this january", mkt(7)},
 		{"next january", mkt(7)},
 		{"last january", mkt(-5)},
-		{"february", mkt(-4)},
-		{"this february", mkt(-4)},
+		{"february", mkt(8)},
+		{"this february", mkt(8)},
 		{"next february", mkt(8)},
 		{"last february", mkt(-4)},
-		{"march", mkt(-3)},
-		{"this march", mkt(-3)},
+		{"march", mkt(9)},
+		{"this march", mkt(9)},
 		{"next march", mkt(9)},
 		{"last march", mkt(-3)},
-		{"april", mkt(-2)},
-		{"this april", mkt(-2)},
+		{"april", mkt(10)},
+		{"this april", mkt(10)},
 		{"next april", mkt(10)},
 		{"last april", mkt(-2)},
-		{"may", mkt(-1)},
-		{"this may", mkt(-1)},
+		{"may", mkt(11)},
+		{"this may", mkt(11)},
 		{"next may", mkt(11)},
 		{"last may", mkt(-1)},
 	}
@@ -468,19 +469,19 @@ func TestAbsDayMonth(t *testing.T) {
 		// ... of implicitly this month
 		{"1st Monday", mkt(2001, 2, 5)},
 		{"1st Wednesday", mkt(2001, 2, 7)},
-		{"1st Thursday", mkt(2001, 2, 1)},
+		{"1st Thursday", mkt(2002, 2, 7)},
 		{"1st Sunday", mkt(2001, 2, 4)},
 		{"2nd Monday", mkt(2001, 2, 12)},
 		{"2nd Wednesday", mkt(2001, 2, 14)},
 		{"2nd Thursday", mkt(2001, 2, 8)},
 		{"2nd Sunday", mkt(2001, 2, 11)},
 		// ... of explicit month
-		{"3rd Saturday of December", mkt(2000, 12, 16)},
-		{"2nd Sunday of January", mkt(2001, 1, 14)},
+		{"3rd Saturday of December", mkt(2001, 12, 15)},
+		{"2nd Sunday of January", mkt(2002, 1, 13)},
 		{"4th Thursday of February", mkt(2001, 2, 22)},
 		{"1st Tuesday of March", mkt(2001, 3, 6)},
 		{"2nd Wednesday of August", mkt(2001, 8, 8)},
-		{"2nd Wednesday of September", mkt(2000, 9, 13)},
+		{"2nd Wednesday of September", mkt(2001, 9, 12)},
 		// ... of explicit month of year
 		{"3rd Tuesday of January 2014", mkt(2014, 1, 21)},
 		{"3rd Friday of January 2014", mkt(2014, 1, 17)},

--- a/util/datetime/future_test.go
+++ b/util/datetime/future_test.go
@@ -37,6 +37,23 @@ func TestFutureBias(t *testing.T) {
 		// Base date: March 20th 2024 (Wed)
 		// 1st Tue: Mar 5, 2nd Tue: Mar 12, 3rd Tue: Mar 19 (passed)
 		{"3rd Tuesday", time.Date(2025, 3, 18, 12, 0, 0, 0, time.UTC)},
+
+		// Leap year edge case
+		// Base date: March 20th 2024
+		// "Feb 29th" 2024 is past, so it bumps to 2025. 2025-02-29 -> 2025-03-01.
+		{"Feb 29th", time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)},
+
+		// Relative day "next Wednesday" when today is Wednesday
+		// Should be next week (March 27th)
+		{"next Wednesday", time.Date(2024, 3, 27, 12, 0, 0, 0, time.UTC)},
+
+		// "this Wednesday" when today is Wednesday
+		// Should be today (March 20th)
+		{"this Wednesday", time.Date(2024, 3, 20, 12, 0, 0, 0, time.UTC)},
+
+		// "last Wednesday" when today is Wednesday
+		// Should be last week (March 13th)
+		{"last Wednesday", time.Date(2024, 3, 13, 12, 0, 0, 0, time.UTC)},
 	}
 
 	for _, test := range tests {

--- a/util/datetime/future_test.go
+++ b/util/datetime/future_test.go
@@ -1,0 +1,53 @@
+package datetime
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFutureBias(t *testing.T) {
+	// Base date: Wed 20th March 2024
+	now := time.Date(2024, 3, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		in  string
+		exp time.Time
+	}{
+		// Past date this year should be next year
+		{"March 1st", time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)},
+		{"1st January", time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+		{"15/3", time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)},
+
+		// Future date this year should stay this year
+		{"March 25th", time.Date(2024, 3, 25, 12, 0, 0, 0, time.UTC)},
+		{"December 25th", time.Date(2024, 12, 25, 12, 0, 0, 0, time.UTC)},
+
+		// Absolute months
+		{"January", time.Date(2025, 1, 20, 12, 0, 0, 0, time.UTC)},
+		{"December", time.Date(2024, 12, 20, 12, 0, 0, 0, time.UTC)},
+
+		// Specified year should NOT be biased
+		{"1st March 2024", time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)},
+		{"March 1st, 2024", time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)},
+
+		// Times in the past should NOT be biased by the parser (driver handles it)
+		{"10:00", time.Date(2024, 3, 20, 10, 0, 0, 0, time.UTC)},
+
+		// 3rd Tuesday of the month (past this month)
+		// Base date: March 20th 2024 (Wed)
+		// 1st Tue: Mar 5, 2nd Tue: Mar 12, 3rd Tue: Mar 19 (passed)
+		{"3rd Tuesday", time.Date(2025, 3, 18, 12, 0, 0, 0, time.UTC)},
+	}
+
+	for _, test := range tests {
+		res, err := parseX(test.in, now)
+		got := res.Time
+		if err != nil {
+			t.Errorf("parse(%q) error: %v", test.in, err)
+			continue
+		}
+		if !got.Equal(test.exp) {
+			t.Errorf("parse(%q) = %v, want %v", test.in, got, test.exp)
+		}
+	}
+}

--- a/util/datetime/lexer.go
+++ b/util/datetime/lexer.go
@@ -132,11 +132,15 @@ type dateLexer struct {
 	*util.Lexer
 	hourfmt, ampmfmt, zonefmt string
 	rel                       time.Time // base time any relative offsets are computed against
+	originalRel               time.Time // base time before any modifications
 	time, date                time.Time // takes care of absolute time and date specs
 	day                       int       // takes care of absolute day of relative month
 	offsets                   relTime   // takes care of +- ymd hms
 	days                      relDays   // takes care of specific days into future
 	months                    relMonths // takes care of specific months into future
+	yearSet                   bool      // takes care of whether the year was explicitly set
+	nextUsed                  bool      // takes care of whether the 'next' token was used
+	pastRequested             bool      // takes care of whether 'last' or 'ago' was used
 	states                    lexerState
 	errors                    []string
 }
@@ -175,6 +179,13 @@ func (l *dateLexer) Lex(lval *yySymType) int {
 		pos := l.Pos()
 		input := l.Scan(unicode.IsLetter)
 		if tok, ok := tokenMaps.Lookup(strings.ToUpper(input), lval); ok {
+			upper := strings.ToUpper(input)
+			if upper == "NEXT" {
+				l.nextUsed = true
+			}
+			if upper == "LAST" || tok == T_AGO {
+				l.pastRequested = true
+			}
 			return tok
 		}
 		// No token recognised, but it could be a zone in IANA format!
@@ -210,6 +221,7 @@ func (l *dateLexer) setUnix(epoch int64) {
 		l.Error("unix timestamp plus other time/date specifier")
 		return
 	}
+	l.yearSet = true
 	l.time = time.Unix(epoch, 0)
 	l.date = l.time
 }
@@ -248,6 +260,9 @@ func (l *dateLexer) setDate(y, m, d int) {
 		l.Error("Parsed two dates")
 		return
 	}
+	if y != 0 {
+		l.yearSet = true
+	}
 	l.date = time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.Local)
 }
 
@@ -265,10 +280,14 @@ func (l *dateLexer) setDays(d, n int, year ...int) {
 	if l.state(HAVE_DAYS, true) {
 		l.Error("Parsed two days")
 	}
+	if n < 0 {
+		l.pastRequested = true
+	}
 	l.days = relDays{time.Weekday(d), n, 0}
 	if len(year) > 0 {
 		l.state(HAVE_DYEAR, true)
 		l.days.year = year[0]
+		l.yearSet = true
 	}
 }
 
@@ -292,15 +311,20 @@ func (l *dateLexer) setMonths(m, n int, year ...int) {
 		l.Error("Parsed two months")
 		return
 	}
+	if n < 0 {
+		l.pastRequested = true
+	}
 	l.months = relMonths{time.Month(m), n, 0}
 	if len(year) > 0 {
 		l.state(HAVE_MYEAR, true)
 		l.months.year = year[0]
+		l.yearSet = true
 	}
 }
 
 func (l *dateLexer) setYear(year int) {
 	DPrintf("Setting year to %d\n", year)
+	l.yearSet = true
 	if l.state(HAVE_DATE) {
 		l.date = time.Date(year, l.date.Month(), l.date.Day(),
 			0, 0, 0, 0, time.Local)
@@ -324,6 +348,7 @@ func (l *dateLexer) setYMD(ymd int, ln int) {
 		}
 	}
 	DPrintf("Setting YYYY-MM-DD to %04d-%02d-%02d\n", year, month, day)
+	l.yearSet = true
 	l.setDate(year, month, day)
 }
 
@@ -363,6 +388,9 @@ func (l *dateLexer) resolveDate() {
 	}
 	h, n, s := l.rel.Clock()
 	l.rel = time.Date(y, m, d, h, n, s, 0, l.rel.Location())
+	if !l.yearSet && l.rel.Before(l.originalRel) {
+		l.rel = l.rel.AddDate(1, 0, 0)
+	}
 }
 
 func (l *dateLexer) resolveDay() {
@@ -376,34 +404,38 @@ func (l *dateLexer) dayOffset() {
 	// refers to the coming <day> unless it refers to the day of this year
 	// or *today* whilst "next <day>" *always* refers to the coming <day>.
 	diff := int(l.days.day - l.rel.Weekday())
-	if diff < 0 && l.days.num <= 0 {
-		DPrintf("Day offset %d->%d, diff=%d.\n", l.days.num, l.days.num+1, diff)
-		l.days.num++
-	} else if diff > 0 && l.days.num > 0 {
-		DPrintf("Day offset %d->%d, diff=%d.\n", l.days.num, l.days.num-1, diff)
-		l.days.num--
+	num := l.days.num
+	if diff < 0 && num <= 0 {
+		DPrintf("Day offset %d->%d, diff=%d.\n", num, num+1, diff)
+		num++
+	} else if diff > 0 && num > 0 {
+		DPrintf("Day offset %d->%d, diff=%d.\n", num, num-1, diff)
+		num--
 	}
-	l.rel = l.rel.AddDate(0, 0, l.days.num*7+diff)
+	l.rel = l.rel.AddDate(0, 0, num*7+diff)
 }
 
 func (l *dateLexer) monthOffset() {
 	diff := int(l.months.month - l.rel.Month())
-	if l.months.num == 0 {
+	num := l.months.num
+	if num == 0 {
 		// If just "march" or "this march" find closest month
-		// preferring 6 months in future over 6 months in past
-		diff = ((diff + 5) % 12) - 5
+		// preferring future over past
+		if diff < 0 {
+			diff += 12
+		}
 		DPrintf("Month offset %d months\n", diff)
 		l.rel = l.rel.AddDate(0, diff, 0)
 		return
 	}
-	if diff < 0 && l.months.num < 0 {
-		DPrintf("Month offset %d->%d, diff=%d.\n", l.months.num, l.months.num+1, diff)
-		l.months.num++
-	} else if diff > 0 && l.months.num > 0 {
-		DPrintf("Month offset %d->%d, diff=%d.\n", l.months.num, l.months.num-1, diff)
-		l.months.num--
+	if diff < 0 && num < 0 {
+		DPrintf("Month offset %d->%d, diff=%d.\n", num, num+1, diff)
+		num++
+	} else if diff > 0 && num > 0 {
+		DPrintf("Month offset %d->%d, diff=%d.\n", num, num-1, diff)
+		num--
 	}
-	l.rel = l.rel.AddDate(0, l.months.num*12+diff, 0)
+	l.rel = l.rel.AddDate(0, num*12+diff, 0)
 }
 
 func (l *dateLexer) resolveDMY() {
@@ -442,6 +474,10 @@ func (l *dateLexer) resolveDMY() {
 		// this is num'th weekday of month, so we need to offset from "0th"
 		l.rel = mkrel(l.rel.Year(), l.rel.Month(), 0)
 		l.dayOffset()
+		if !l.yearSet && !l.pastRequested && l.rel.Before(l.originalRel) {
+			l.rel = mkrel(l.rel.Year()+1, l.months.month, 0)
+			l.dayOffset()
+		}
 	case HAVE_MYEAR:
 		DPrintf("MYEAR\n")
 		// These on their own are a little odd but probably due to the hack at
@@ -506,27 +542,46 @@ func (l *dateLexer) resolve() (time.Time, error) {
 		l.resolveDMY()
 		DPrintf("HAVE_DMY after: %s %s\n", l.rel.Weekday(), l.rel)
 	}
+	if (l.states&(HAVE_DATE|HAVE_DAY|HAVE_DAYS|HAVE_MONTHS)) != 0 && !l.yearSet && !l.pastRequested && l.rel.Before(l.originalRel) {
+		l.rel = l.rel.AddDate(1, 0, 0)
+	}
 	return l.rel, nil
 }
 
-func parse(input string, rel time.Time) (time.Time, error) {
+type ParseResult struct {
+	Time     time.Time
+	NextUsed bool
+}
+
+func parseX(input string, rel time.Time) (ParseResult, error) {
 	yyDebug = 0
 	yyErrorVerbose = true
 
-	lexer := &dateLexer{Lexer: &util.Lexer{Input: input}, rel: rel}
+	lexer := &dateLexer{Lexer: &util.Lexer{Input: input}, rel: rel, originalRel: rel}
 	if ret := yyParse(lexer); ret != 0 {
-		return time.Time{}, errors.New(strings.Join(lexer.errors, "; "))
+		return ParseResult{}, errors.New(strings.Join(lexer.errors, "; "))
 	}
 	if lexer.states == 0 {
-		return time.Time{}, errors.New("no dates parsed from input")
+		return ParseResult{}, errors.New("no dates parsed from input")
 	}
-	return lexer.resolve()
+	t, err := lexer.resolve()
+	return ParseResult{t, lexer.nextUsed}, err
 }
 
 func Parse(input string) (time.Time, error) {
-	return parse(input, time.Now().In(local))
+	res, err := parseX(input, time.Now().In(local))
+	return res.Time, err
 }
 
 func ParseZ(input string, zone *time.Location) (time.Time, error) {
-	return parse(input, time.Now().In(zone))
+	res, err := parseX(input, time.Now().In(zone))
+	return res.Time, err
+}
+
+func ParseX(input string) (ParseResult, error) {
+	return parseX(input, time.Now().In(local))
+}
+
+func ParseXZ(input string, zone *time.Location) (ParseResult, error) {
+	return parseX(input, time.Now().In(zone))
 }


### PR DESCRIPTION
The changes improve the usability and reliability of the reminder system by correctly interpreting dates in a future-biased way and clarifying ambiguous inputs like 'next'. Past times now correctly trigger an error, and the user is explicitly informed when a reminder is set for a future year.

---
*PR created automatically by Jules for task [13181445197781982823](https://jules.google.com/task/13181445197781982823) started by @gundalow*