### PR TITLE
Update Go to 1.25 and configure Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 10%
+    patch:
+      default:
+        enabled: no

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,10 +21,21 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+      run: |
+        go install github.com/jstemmer/go-junit-report/v2@latest
+        go test -v -race -coverprofile=coverage.txt -covermode=atomic ./... 2>&1 | go-junit-report -set-exit-code > junit.xml
 
     - name: Upload coverage reports to Codecov
+      if: ${{ !cancelled() }}
       uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.txt
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./junit.xml
+        report-type: test_results

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.25'
 
@@ -24,7 +24,7 @@ jobs:
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.txt
+        files: ./coverage.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as build-env
+FROM golang:1.25 as build-env
 
 WORKDIR /go/src/github.com/fluffle/sp0rkle
 ADD . /go/src/github.com/fluffle/sp0rkle


### PR DESCRIPTION
This PR updates the project's Go version to 1.25 across Docker and GitHub Actions. It also introduces a `.github/codecov.yml` configuration file to streamline coverage reporting, setting a 10% project target and disabling patch coverage noise. The CI workflow is confirmed to generate `coverage.txt` using `go test -coverprofile`.

---
*PR created automatically by Jules for task [16979287562504367899](https://jules.google.com/task/16979287562504367899) started by @gundalow*